### PR TITLE
Tests are failing due to "apitrace --diff" change

### DIFF
--- a/cli/cli-trim-no-side-effects-prune-and-trim.script
+++ b/cli/cli-trim-no-side-effects-prune-and-trim.script
@@ -12,7 +12,7 @@ apitrace trim --prune --deps --trim-spec=no-side-effects --frames=1 few-side-eff
 # Verify that we actually trimmed what we wanted to (just calls with
 # no side effects)
 
-apitrace diff --diff=python few-side-effects.trace few-side-effects-trim.trace
+apitrace diff --tool=python few-side-effects.trace few-side-effects-trim.trace
 expect r"""  glXChooseVisual(31941248, 0, (GLX_RGBA, GLX_RED_SIZE, GLX_RED_SIZE, GLX_GREEN_SIZE, GLX_RED_SIZE, GLX_BLUE_SIZE, GLX_RED_SIZE, GLX_ALPHA_SIZE, GLX_RED_SIZE, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, GLX_STENCIL_SIZE, GLX_RED_SIZE, GLX_X_VISUAL_TYPE, GLX_DIRECT_COLOR, 0)) = ([31985400, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8])
   glXCreateContext(31941248, ([31985400, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8]), 0, True) = 32022336
   glXMakeCurrent(31941248, 60817409, 32022336) = True

--- a/cli/cli-trim-no-side-effects-prune.script
+++ b/cli/cli-trim-no-side-effects-prune.script
@@ -6,7 +6,7 @@ apitrace trim --no-deps --prune few-side-effects.trace
 # Verify that we actually trimmed what we wanted to (just calls with
 # no side effects)
 
-apitrace diff --diff=python few-side-effects.trace few-side-effects-trim.trace
+apitrace diff --tool=python few-side-effects.trace few-side-effects-trim.trace
 expect r"""  glXChooseVisual(31941248, 0, (GLX_RGBA, GLX_RED_SIZE, GLX_RED_SIZE, GLX_GREEN_SIZE, GLX_RED_SIZE, GLX_BLUE_SIZE, GLX_RED_SIZE, GLX_ALPHA_SIZE, GLX_RED_SIZE, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, GLX_STENCIL_SIZE, GLX_RED_SIZE, GLX_X_VISUAL_TYPE, GLX_DIRECT_COLOR, 0)) = ([31985400, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8])
   glXCreateContext(31941248, ([31985400, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8]), 0, True) = 32022336
   glXMakeCurrent(31941248, 60817409, 32022336) = True

--- a/cli/cli-trim-no-side-effects-trim.script
+++ b/cli/cli-trim-no-side-effects-trim.script
@@ -9,7 +9,7 @@ apitrace trim --no-prune --deps --trim-spec=no-side-effects --frames=1 few-side-
 # Verify that we actually trimmed what we wanted to (just calls with
 # no side effects)
 
-apitrace diff --diff=python few-side-effects.trace few-side-effects-trim.trace
+apitrace diff --tool=python few-side-effects.trace few-side-effects-trim.trace
 expect r"""  glXChooseVisual(31941248, 0, (GLX_RGBA, GLX_RED_SIZE, GLX_RED_SIZE, GLX_GREEN_SIZE, GLX_RED_SIZE, GLX_BLUE_SIZE, GLX_RED_SIZE, GLX_ALPHA_SIZE, GLX_RED_SIZE, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, GLX_STENCIL_SIZE, GLX_RED_SIZE, GLX_X_VISUAL_TYPE, GLX_DIRECT_COLOR, 0)) = ([31985400, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8])
   glXCreateContext(31941248, ([31985400, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8]), 0, True) = 32022336
   glXMakeCurrent(31941248, 60817409, 32022336) = True

--- a/cli/cli-trim-spec-all.script
+++ b/cli/cli-trim-spec-all.script
@@ -4,7 +4,7 @@ apitrace trim --auto --calls=88 glxsimple.trace
 
 # Verify that we actually trimmed what we wanted to (most of the trace)
 
-apitrace diff --diff=python glxsimple.trace glxsimple-trim.trace
+apitrace diff --tool=python glxsimple.trace glxsimple-trim.trace
 expect r"""  glXChooseVisual(37134976, 0, (GLX_RGBA, GLX_RED_SIZE, GLX_RED_SIZE, GLX_GREEN_SIZE, GLX_RED_SIZE, GLX_BLUE_SIZE, GLX_RED_SIZE, GLX_ALPHA_SIZE, GLX_RED_SIZE, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, GLX_STENCIL_SIZE, GLX_RED_SIZE, GLX_X_VISUAL_TYPE, GLX_DIRECT_COLOR, 0)) = ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8])
   glXCreateContext(37134976, ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8]), 0, True) = 37241648
   glXMakeCurrent(37134976, 41943041, 37241648) = True

--- a/cli/cli-trim-spec-drawing.script
+++ b/cli/cli-trim-spec-drawing.script
@@ -4,7 +4,7 @@ apitrace trim --auto --trim-spec=drawing --calls=88 glxsimple.trace
 
 # Verify that we actually trimmed what we wanted to (just drawing calls)
 
-apitrace diff --diff=python glxsimple.trace glxsimple-trim.trace
+apitrace diff --tool=python glxsimple.trace glxsimple-trim.trace
 expect r"""  glXChooseVisual(37134976, 0, (GLX_RGBA, GLX_RED_SIZE, GLX_RED_SIZE, GLX_GREEN_SIZE, GLX_RED_SIZE, GLX_BLUE_SIZE, GLX_RED_SIZE, GLX_ALPHA_SIZE, GLX_RED_SIZE, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, GLX_STENCIL_SIZE, GLX_RED_SIZE, GLX_X_VISUAL_TYPE, GLX_DIRECT_COLOR, 0)) = ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8])
   glXCreateContext(37134976, ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8]), 0, True) = 37241648
   glXMakeCurrent(37134976, 41943041, 37241648) = True

--- a/cli/cli-trim-spec-shaders.script
+++ b/cli/cli-trim-spec-shaders.script
@@ -4,7 +4,7 @@ apitrace trim --auto --trim-spec=shaders --calls=88 glxsimple.trace
 
 # Verify that we actually trimmed what we wanted to (just shader-generation calls)
 
-apitrace diff --diff=python glxsimple.trace glxsimple-trim.trace
+apitrace diff --tool=python glxsimple.trace glxsimple-trim.trace
 expect r"""  glXChooseVisual(37134976, 0, (GLX_RGBA, GLX_RED_SIZE, GLX_RED_SIZE, GLX_GREEN_SIZE, GLX_RED_SIZE, GLX_BLUE_SIZE, GLX_RED_SIZE, GLX_ALPHA_SIZE, GLX_RED_SIZE, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, GLX_STENCIL_SIZE, GLX_RED_SIZE, GLX_X_VISUAL_TYPE, GLX_DIRECT_COLOR, 0)) = ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8])
   glXCreateContext(37134976, ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8]), 0, True) = 37241648
   glXMakeCurrent(37134976, 41943041, 37241648) = True

--- a/cli/cli-trim-spec-textures.script
+++ b/cli/cli-trim-spec-textures.script
@@ -4,7 +4,7 @@ apitrace trim --auto --trim-spec=textures --calls=88 glxsimple.trace
 
 # Verify that we actually trimmed what we wanted to (just texture-generation calls)
 
-apitrace diff --diff=python glxsimple.trace glxsimple-trim.trace
+apitrace diff --tool=python glxsimple.trace glxsimple-trim.trace
 expect r"""  glXChooseVisual(37134976, 0, (GLX_RGBA, GLX_RED_SIZE, GLX_RED_SIZE, GLX_GREEN_SIZE, GLX_RED_SIZE, GLX_BLUE_SIZE, GLX_RED_SIZE, GLX_ALPHA_SIZE, GLX_RED_SIZE, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, GLX_STENCIL_SIZE, GLX_RED_SIZE, GLX_X_VISUAL_TYPE, GLX_DIRECT_COLOR, 0)) = ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8])
   glXCreateContext(37134976, ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8]), 0, True) = 37241648
   glXMakeCurrent(37134976, 41943041, 37241648) = True

--- a/cli/cli-trim-unused-shaders.script
+++ b/cli/cli-trim-unused-shaders.script
@@ -12,7 +12,7 @@ apitrace trim --auto --calls=10,47,50,71,87,88 glxsimple.trace
 
 # Verify that we actually trimmed what we wanted to
 
-apitrace diff --diff=python glxsimple.trace glxsimple-trim.trace
+apitrace diff --tool=python glxsimple.trace glxsimple-trim.trace
 expect r"""  glXChooseVisual(37134976, 0, (GLX_RGBA, GLX_RED_SIZE, GLX_RED_SIZE, GLX_GREEN_SIZE, GLX_RED_SIZE, GLX_BLUE_SIZE, GLX_RED_SIZE, GLX_ALPHA_SIZE, GLX_RED_SIZE, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, GLX_STENCIL_SIZE, GLX_RED_SIZE, GLX_X_VISUAL_TYPE, GLX_DIRECT_COLOR, 0)) = ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8])
   glXCreateContext(37134976, ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8]), 0, True) = 37241648
   glXMakeCurrent(37134976, 41943041, 37241648) = True

--- a/cli/cli-trim-unused-textures.script
+++ b/cli/cli-trim-unused-textures.script
@@ -12,7 +12,7 @@ apitrace trim --auto -o glxsimple-trim-unused-textures.trace --calls=10,31,50,71
 
 # Verify that we actually trimmed what we wanted to
 
-apitrace diff --diff=python glxsimple.trace glxsimple-trim-unused-textures.trace
+apitrace diff --tool=python glxsimple.trace glxsimple-trim-unused-textures.trace
 expect r"""  glXChooseVisual(37134976, 0, (GLX_RGBA, GLX_RED_SIZE, GLX_RED_SIZE, GLX_GREEN_SIZE, GLX_RED_SIZE, GLX_BLUE_SIZE, GLX_RED_SIZE, GLX_ALPHA_SIZE, GLX_RED_SIZE, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, GLX_STENCIL_SIZE, GLX_RED_SIZE, GLX_X_VISUAL_TYPE, GLX_DIRECT_COLOR, 0)) = ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8])
   glXCreateContext(37134976, ([37179128, 34, 0, 24, 5, 16711680, 65280, 255, 256, 8]), 0, True) = 37241648
   glXMakeCurrent(37134976, 41943041, 37241648) = True


### PR DESCRIPTION
After a recent sync to upstream, the following tests were found to be
failing:

   cli/cli-trim-no-side-effects-prune-and-trim.script
   cli/cli-trim-no-side-effects-prune.script
   cli/cli-trim-no-side-effects-trim.script
   cli/cli-trim-spec-all.script
   cli/cli-trim-spec-drawing.script
   cli/cli-trim-spec-shaders.script
   cli/cli-trim-spec-textures.script
   cli/cli-trim-unused-shaders.script
   cli/cli-trim-unused-textures.script

Cause of failure found to be due to commit
155380f 2013-10-18 tracediff: Rename --diff=TOOL option to --tool=TOOL.

Fix was to change scripts to all the failing tests to use "--tool"
instead of "--diff"
## TESTING

Re-ran test suite and all tests passed.

Checked "apitrace help diff" output to confirm reflection of "--tool"
change

Looked through markdown documentation. Didn't find any changes that
needed to be made.

Signed-off-by: Lawrence L Love lawrencex.l.love@intel.com
